### PR TITLE
Add EU Support

### DIFF
--- a/db/migrate/20160809160330_add_country_code.rb
+++ b/db/migrate/20160809160330_add_country_code.rb
@@ -1,0 +1,5 @@
+class AddCountryCode < ActiveRecord::Migration
+  def change
+    add_column :merchants, :country_code, :string, :default => 'USA'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151002181155) do
+ActiveRecord::Schema.define(version: 20160809160330) do
 
   create_table "merchants", force: :cascade do |t|
     t.string   "email"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 20151002181155) do
     t.string   "state"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "country_code",                      default: "USA"
   end
 
 end

--- a/models/prefill_data.rb
+++ b/models/prefill_data.rb
@@ -1,0 +1,67 @@
+module PrefillData
+  def self.user_and_business(country_code)
+    case country_code
+    when "USA"
+      _template.deep_merge(
+        {
+          :user => {
+            :phone => "312-555-5555",
+            :country => "USA",
+          },
+          :business => {
+            :phone => "312-555-5555",
+            :currency => "USD",
+            :street_address => "222 W Merchandise Mart Plaza",
+            :locality => "Chicago",
+            :region => "IL",
+            :postal_code => "60654",
+            :country => "USA",
+          },
+        }
+      )
+    when "GBR"
+      _template.deep_merge(
+        {
+          :user => {
+            :phone => "+4403457345345",
+            :country => "GBR",
+          },
+          :business => {
+            :phone => "+4403457345345",
+            :currency => "GBP",
+            :street_address => "123 Alderson Road",
+            :postal_code => "NR30 1QG",
+            :locality => "Great Yarmouth",
+            :region => "Norfolk",
+            :country => "GBR",
+          },
+        }
+      )
+    else
+      _template
+    end
+  end
+
+  def self._template
+    {
+      :user => {
+        :first_name => "Bob",
+        :last_name => "Merchant",
+        :dob_day => "01",
+        :dob_month => "01",
+        :dob_year => "1970",
+      },
+      :business => {
+        :name => "Example CO",
+        :registered_as => "limited_liability_corporation",
+        :industry => "software",
+        :website => "https://example.com",
+        :description => "send money",
+        :annual_volume_amount => "50,000",
+        :average_transaction_amount => "10",
+        :maximum_transaction_amount => "100",
+        :ship_physical_goods => false,
+      },
+    }
+  end
+end

--- a/prefill.rb
+++ b/prefill.rb
@@ -1,0 +1,67 @@
+module Prefill
+  def _template
+    {
+      :user => {
+        :first_name => "Bob",
+        :last_name => "Merchant",
+        :dob_day => "01",
+        :dob_month => "01",
+        :dob_year => "1970",
+      },
+      :business => {
+        :name => "Example CO",
+        :registered_as => "limited_liability_corporation",
+        :industry => "software",
+        :website => "https://example.com",
+        :description => "send money",
+        :annual_volume_amount => "50,000",
+        :average_transaction_amount => "10",
+        :maximum_transaction_amount => "100",
+        :ship_physical_goods => false,
+      },
+    }
+  end
+
+  def user_and_business(country_code)
+    case country_code
+    when "USA"
+      _template.deep_merge(
+        {
+          :user => {
+            :phone => "312-555-5555",
+            :country => "USA",
+          },
+          :business => {
+            :phone => "312-555-5555",
+            :currency => "USD",
+            :street_address => "222 W Merchandise Mart Plaza",
+            :locality => "Chicago",
+            :region => "IL",
+            :postal_code => "60654",
+            :country => "USA",
+          },
+        }
+      )
+    when "GBR"
+      _template.deep_merge(
+        {
+          :user => {
+            :phone => "+4403457345345",
+            :country => "GBR",
+          },
+          :business => {
+            :phone => "+4403457345345",
+            :currency => "GBP",
+            :street_address => "123 Alderson Road",
+            :postal_code => "NR30 1QG",
+            :locality => "Great Yarmouth",
+            :region => "Norfolk",
+            :country => "GBR",
+          },
+        }
+      )
+    else
+      _template
+    end
+  end
+end

--- a/views/index.erb
+++ b/views/index.erb
@@ -21,8 +21,9 @@
               <ul>
                 <li>
                   <div class="select-container">
-                    <select name="merchant[country_code_alpha3]">
-                      <option value="USA">United States</option>
+                    <select name="country_code">
+                      <option value="GBR">United Kingdom</option>
+                      <option value="USA" selected>United States</option>
                     </select>
                   </div>
                 </li>


### PR DESCRIPTION
Currently, PseudoShop only supports US merchants. 

This PR adds ability to support UK merchants in Pseudoshop, and passes relevant data to the Gateway. 
