### PR TITLE
Add 3DS

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,5 @@
+GATEWAY_HOST='sandbox.braintreegateway.com'
+GATEWAY_ENVIRONMENT='sandbox'
 CLIENT_ID='client_id$sandbox$g4dqw27b5tnsb326'
 CLIENT_SECRET='client_secret$sandbox$87a138f4870053541a02b01b77ae86e9'
 REDIRECT_URI='http://127.0.0.1:4567/callback'

--- a/app.rb
+++ b/app.rb
@@ -8,6 +8,8 @@ require 'dotenv'
 Dotenv.load
 
 set :database, ENV['DATABASE_URL'] || {:adapter => "sqlite3", :database => "db/development.sqlite3"}
+set :gateway_environment, ENV['GATEWAY_ENVIRONMENT'] || "sandbox"
+set :gateway_host, ENV['GATEWAY_HOST'] || "sandbox.braintreegateway.com"
 
 Dir[File.dirname(__FILE__) + "/models/*.rb"].each { |file| require file }
 
@@ -124,7 +126,7 @@ end
 def _merchant_gateway(merchant)
   Braintree::Gateway.new({
     :access_token => merchant.braintree_access_token,
-    :environment => "sandbox",
+    :environment => settings.gateway_environment,
   })
 end
 
@@ -132,6 +134,6 @@ def _oauth_gateway
   Braintree::Gateway.new({
     :client_id => ENV["CLIENT_ID"],
     :client_secret => ENV["CLIENT_SECRET"],
-    :environment => "sandbox",
+    :environment => settings.gateway_environment,
   })
 end

--- a/public/assets/css/components/_bar.scss
+++ b/public/assets/css/components/_bar.scss
@@ -112,6 +112,55 @@ $bar-height: 54px;
     margin-top: -60px;
   }
 
+  .error {
+    position: absolute;
+    background-color: #fff;
+    width: 100%;
+    height: 100%;
+    left: 0px;
+    top: 100%;
+    z-index: 2;
+    text-align: center;
+    opacity: 0;
+    @include transition(opacity .4s ease-in-out);
+
+    h3,
+    p,
+    .icon {
+      opacity: 0;
+      @include transform(translateY(100px));
+      @include transition(transform .4s cubic-bezier(0.165, 0.84, 0.44, 1), opacity .4s ease);
+    }
+    
+    &.show {
+      opacity: 1;
+      top: 0%;
+
+      h3, 
+      p,
+      .icon {
+        opacity: 1;
+        @include transform(translateY(0px));
+      }
+
+      h3 {
+        @include transition-delay(.1s);
+      }
+      
+      p {
+        @include transition-delay(.2s);
+      }
+    }
+  }
+  
+  .error-content {
+    @extend .middle-wrapper;
+  }
+
+  .error-middle {
+    @extend .middle;
+  }
+
   a.toggle {
     @include transition(background-color .4s linear, color .4s linear, width .2s cubic-bezier(0.77, 0, 0.175, 1), opacity .2s ease);
     font-family: 'bt_mono_medium', monospace;

--- a/public/assets/css/components/_bar.scss
+++ b/public/assets/css/components/_bar.scss
@@ -12,7 +12,7 @@ $bar-height: 54px;
   .container {
     height: 100%;
   }
-  
+
   ul,
   ul > li {
     display: inline-block;
@@ -20,7 +20,7 @@ $bar-height: 54px;
     float: left;
   }
 
-  ul { 
+  ul {
     float: right;
     margin: 0;
 
@@ -36,7 +36,7 @@ $bar-height: 54px;
     text-align: center;
     margin-top: 1.5em;
 
-    &:hover, 
+    &:hover,
     &:focus {
       background-color: darken(#2CA1E9, 8%);
     }
@@ -49,7 +49,7 @@ $bar-height: 54px;
   position: relative;
 
   @include transition(transform .4s cubic-bezier(0.645, 0.045, 0.355, 1), box-shadow .4s linear);
-  
+
   section {
     clear: both;
     position: relative;
@@ -74,12 +74,12 @@ $bar-height: 54px;
       @include transform(translateY(100px));
       @include transition(transform .4s cubic-bezier(0.165, 0.84, 0.44, 1), opacity .4s ease);
     }
-    
+
     &.show {
       opacity: 1;
       top: 0%;
 
-      h3, 
+      h3,
       p,
       .icon {
         opacity: 1;
@@ -89,13 +89,13 @@ $bar-height: 54px;
       h3 {
         @include transition-delay(.1s);
       }
-      
+
       p {
         @include transition-delay(.2s);
       }
     }
   }
-  
+
   .success-content {
     @extend .middle-wrapper;
   }
@@ -131,12 +131,12 @@ $bar-height: 54px;
       @include transform(translateY(100px));
       @include transition(transform .4s cubic-bezier(0.165, 0.84, 0.44, 1), opacity .4s ease);
     }
-    
+
     &.show {
       opacity: 1;
       top: 0%;
 
-      h3, 
+      h3,
       p,
       .icon {
         opacity: 1;
@@ -146,13 +146,13 @@ $bar-height: 54px;
       h3 {
         @include transition-delay(.1s);
       }
-      
+
       p {
         @include transition-delay(.2s);
       }
     }
   }
-  
+
   .error-content {
     @extend .middle-wrapper;
   }
@@ -170,7 +170,7 @@ $bar-height: 54px;
     display: block;
     float: right;
     width: auto;
-    text-decoration: none; 
+    text-decoration: none;
     height: $bar-height;
     line-height: $bar-height;
     padding: 0 30px;
@@ -211,9 +211,9 @@ $bar-height: 54px;
     top: 0px;
   }
 
-  &.open { 
+  &.open {
     box-shadow: 0px 0px 14px rgba(0,0,0,.14), 0px 0px 3px rgba(0,0,0,.14);
-    
+
     a.toggle {
       background-color: $color-dark;
       color: #fff;
@@ -226,7 +226,7 @@ $bar-height: 54px;
     .detail {
       opacity: .6;
     }
-  } 
+  }
 
   .pane-content {
     background-color: #fff;

--- a/public/assets/css/global.css
+++ b/public/assets/css/global.css
@@ -1,8 +1,12 @@
+/* line 4, vendor/neat/grid/_box-sizing.scss */
 html {
-  box-sizing: border-box; }
+  box-sizing: border-box;
+}
 
+/* line 9, vendor/neat/grid/_box-sizing.scss */
 *, *::after, *::before {
-  box-sizing: inherit; }
+  box-sizing: inherit;
+}
 
 /*! normalize.css v3.0.2 | MIT License | git.io/normalize */
 /**
@@ -10,19 +14,23 @@ html {
  * 2. Prevent iOS text size adjust after orientation change, without disabling
  *    user zoom.
  */
+/* line 9, vendor/_normalize.scss */
 html {
   font-family: sans-serif;
   /* 1 */
   -ms-text-size-adjust: 100%;
   /* 2 */
   -webkit-text-size-adjust: 100%;
-  /* 2 */ }
+  /* 2 */
+}
 
 /**
  * Remove default margin.
  */
+/* line 19, vendor/_normalize.scss */
 body {
-  margin: 0; }
+  margin: 0;
+}
 
 /* HTML5 display definitions
 ========================================================================== */
@@ -32,6 +40,7 @@ body {
  * and Firefox.
  * Correct `block` display not defined for `main` in IE 11.
  */
+/* line 33, vendor/_normalize.scss */
 article,
 aside,
 details,
@@ -45,12 +54,14 @@ menu,
 nav,
 section,
 summary {
-  display: block; }
+  display: block;
+}
 
 /**
  * 1. Correct `inline-block` display not defined in IE 8/9.
  * 2. Normalize vertical alignment of `progress` in Chrome, Firefox, and Opera.
  */
+/* line 54, vendor/_normalize.scss */
 audio,
 canvas,
 progress,
@@ -58,142 +69,181 @@ video {
   display: inline-block;
   /* 1 */
   vertical-align: baseline;
-  /* 2 */ }
+  /* 2 */
+}
 
 /**
  * Prevent modern browsers from displaying `audio` without controls.
  * Remove excess height in iOS 5 devices.
  */
+/* line 67, vendor/_normalize.scss */
 audio:not([controls]) {
   display: none;
-  height: 0; }
+  height: 0;
+}
 
 /**
  * Address `[hidden]` styling not present in IE 8/9/10.
  * Hide the `template` element in IE 8/9/11, Safari, and Firefox < 22.
  */
+/* line 77, vendor/_normalize.scss */
 [hidden],
 template {
-  display: none; }
+  display: none;
+}
 
 /* Links
 ========================================================================== */
 /**
  * Remove the gray background color from active links in IE 10.
  */
+/* line 89, vendor/_normalize.scss */
 a {
-  background-color: transparent; }
+  background-color: transparent;
+}
 
 /**
  * Improve readability when focused and also mouse hovered in all browsers.
  */
+/* line 97, vendor/_normalize.scss */
 a:active,
 a:hover {
-  outline: 0; }
+  outline: 0;
+}
 
 /* Text-level semantics
 ========================================================================== */
 /**
  * Address styling not present in IE 8/9/10/11, Safari, and Chrome.
  */
+/* line 109, vendor/_normalize.scss */
 abbr[title] {
-  border-bottom: 1px dotted; }
+  border-bottom: 1px dotted;
+}
 
 /**
  * Address style set to `bolder` in Firefox 4+, Safari, and Chrome.
  */
+/* line 117, vendor/_normalize.scss */
 b,
 strong {
-  font-weight: bold; }
+  font-weight: bold;
+}
 
 /**
  * Address styling not present in Safari and Chrome.
  */
+/* line 126, vendor/_normalize.scss */
 dfn {
-  font-style: italic; }
+  font-style: italic;
+}
 
 /**
  * Address variable `h1` font-size and margin within `section` and `article`
  * contexts in Firefox 4+, Safari, and Chrome.
  */
+/* line 135, vendor/_normalize.scss */
 h1 {
   font-size: 2em;
-  margin: 0.67em 0; }
+  margin: 0.67em 0;
+}
 
 /**
  * Address styling not present in IE 8/9.
  */
+/* line 144, vendor/_normalize.scss */
 mark {
   background: #ff0;
-  color: #000; }
+  color: #000;
+}
 
 /**
  * Address inconsistent and variable font size in all browsers.
  */
+/* line 153, vendor/_normalize.scss */
 small {
-  font-size: 80%; }
+  font-size: 80%;
+}
 
 /**
  * Prevent `sub` and `sup` affecting `line-height` in all browsers.
  */
+/* line 161, vendor/_normalize.scss */
 sub,
 sup {
   font-size: 75%;
   line-height: 0;
   position: relative;
-  vertical-align: baseline; }
+  vertical-align: baseline;
+}
 
+/* line 169, vendor/_normalize.scss */
 sup {
-  top: -0.5em; }
+  top: -0.5em;
+}
 
+/* line 173, vendor/_normalize.scss */
 sub {
-  bottom: -0.25em; }
+  bottom: -0.25em;
+}
 
 /* Embedded content
 ========================================================================== */
 /**
  * Remove border when inside `a` element in IE 8/9/10.
  */
+/* line 184, vendor/_normalize.scss */
 img {
-  border: 0; }
+  border: 0;
+}
 
 /**
  * Correct overflow not hidden in IE 9/10/11.
  */
+/* line 192, vendor/_normalize.scss */
 svg:not(:root) {
-  overflow: hidden; }
+  overflow: hidden;
+}
 
 /* Grouping content
 ========================================================================== */
 /**
  * Address margin not present in IE 8/9 and Safari.
  */
+/* line 203, vendor/_normalize.scss */
 figure {
-  margin: 1em 40px; }
+  margin: 1em 40px;
+}
 
 /**
  * Address differences between Firefox and other browsers.
  */
+/* line 211, vendor/_normalize.scss */
 hr {
   -moz-box-sizing: content-box;
   box-sizing: content-box;
-  height: 0; }
+  height: 0;
+}
 
 /**
  * Contain overflow in all browsers.
  */
+/* line 221, vendor/_normalize.scss */
 pre {
-  overflow: auto; }
+  overflow: auto;
+}
 
 /**
  * Address odd `em`-unit font size rendering in all browsers.
  */
+/* line 229, vendor/_normalize.scss */
 code,
 kbd,
 pre,
 samp {
   font-family: monospace, monospace;
-  font-size: 1em; }
+  font-size: 1em;
+}
 
 /* Forms
 ========================================================================== */
@@ -207,6 +257,7 @@ samp {
  * 2. Correct font properties not being inherited.
  * 3. Address margins set differently in Firefox 4+, Safari, and Chrome.
  */
+/* line 252, vendor/_normalize.scss */
 button,
 input,
 optgroup,
@@ -217,13 +268,16 @@ textarea {
   font: inherit;
   /* 2 */
   margin: 0;
-  /* 3 */ }
+  /* 3 */
+}
 
 /**
  * Address `overflow` set to `hidden` in IE 8/9/10/11.
  */
+/* line 266, vendor/_normalize.scss */
 button {
-  overflow: visible; }
+  overflow: visible;
+}
 
 /**
  * Address inconsistent `text-transform` inheritance for `button` and `select`.
@@ -231,9 +285,11 @@ button {
  * Correct `button` style inheritance in Firefox, IE 8/9/10/11, and Opera.
  * Correct `select` style inheritance in Firefox.
  */
+/* line 277, vendor/_normalize.scss */
 button,
 select {
-  text-transform: none; }
+  text-transform: none;
+}
 
 /**
  * 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio`
@@ -242,6 +298,7 @@ select {
  * 3. Improve usability and consistency of cursor style between image-type
  *    `input` and others.
  */
+/* line 290, vendor/_normalize.scss */
 button,
 html input[type="button"],
 input[type="reset"],
@@ -249,29 +306,36 @@ input[type="submit"] {
   -webkit-appearance: button;
   /* 2 */
   cursor: pointer;
-  /* 3 */ }
+  /* 3 */
+}
 
 /**
  * Re-set default cursor for disabled elements.
  */
+/* line 302, vendor/_normalize.scss */
 button[disabled],
 html input[disabled] {
-  cursor: default; }
+  cursor: default;
+}
 
 /**
  * Remove inner padding and border in Firefox 4+.
  */
+/* line 311, vendor/_normalize.scss */
 button::-moz-focus-inner,
 input::-moz-focus-inner {
   border: 0;
-  padding: 0; }
+  padding: 0;
+}
 
 /**
  * Address Firefox 4+ setting `line-height` on `input` using `!important` in
  * the UA stylesheet.
  */
+/* line 322, vendor/_normalize.scss */
 input {
-  line-height: normal; }
+  line-height: normal;
+}
 
 /**
  * It's recommended that you don't attempt to style these elements.
@@ -280,101 +344,128 @@ input {
  * 1. Address box sizing set to `content-box` in IE 8/9/10.
  * 2. Remove excess padding in IE 8/9/10.
  */
+/* line 334, vendor/_normalize.scss */
 input[type="checkbox"],
 input[type="radio"] {
   box-sizing: border-box;
   /* 1 */
   padding: 0;
-  /* 2 */ }
+  /* 2 */
+}
 
 /**
  * Fix the cursor style for Chrome's increment/decrement buttons. For certain
  * `font-size` values of the `input`, it causes the cursor style of the
  * decrement button to change from `default` to `text`.
  */
+/* line 346, vendor/_normalize.scss */
 input[type="number"]::-webkit-inner-spin-button,
 input[type="number"]::-webkit-outer-spin-button {
-  height: auto; }
+  height: auto;
+}
 
 /**
  * 1. Address `appearance` set to `searchfield` in Safari and Chrome.
  * 2. Address `box-sizing` set to `border-box` in Safari and Chrome
  *    (include `-moz` to future-proof).
  */
+/* line 357, vendor/_normalize.scss */
 input[type="search"] {
   -webkit-appearance: textfield;
   /* 1 */
   -moz-box-sizing: content-box;
   -webkit-box-sizing: content-box;
   /* 2 */
-  box-sizing: content-box; }
+  box-sizing: content-box;
+}
 
 /**
  * Remove inner padding and search cancel button in Safari and Chrome on OS X.
  * Safari (but not Chrome) clips the cancel button when the search input has
  * padding (and `textfield` appearance).
  */
+/* line 370, vendor/_normalize.scss */
 input[type="search"]::-webkit-search-cancel-button,
 input[type="search"]::-webkit-search-decoration {
-  -webkit-appearance: none; }
+  -webkit-appearance: none;
+}
 
 /**
  * Define consistent border, margin, and padding.
  */
+/* line 379, vendor/_normalize.scss */
 fieldset {
   border: 1px solid #c0c0c0;
   margin: 0 2px;
-  padding: 0.35em 0.625em 0.75em; }
+  padding: 0.35em 0.625em 0.75em;
+}
 
 /**
  * 1. Correct `color` not being inherited in IE 8/9/10/11.
  * 2. Remove padding so people aren't caught out if they zero out fieldsets.
  */
+/* line 390, vendor/_normalize.scss */
 legend {
   border: 0;
   /* 1 */
   padding: 0;
-  /* 2 */ }
+  /* 2 */
+}
 
 /**
  * Remove default vertical scrollbar in IE 8/9/10/11.
  */
+/* line 399, vendor/_normalize.scss */
 textarea {
-  overflow: auto; }
+  overflow: auto;
+}
 
 /**
  * Don't inherit the `font-weight` (applied by a rule above).
  * NOTE: the default cannot safely be changed in Chrome and Safari on OS X.
  */
+/* line 408, vendor/_normalize.scss */
 optgroup {
-  font-weight: bold; }
+  font-weight: bold;
+}
 
 /* Tables
 ========================================================================== */
 /**
  * Remove most spacing between table cells.
  */
+/* line 419, vendor/_normalize.scss */
 table {
   border-collapse: collapse;
-  border-spacing: 0; }
+  border-spacing: 0;
+}
 
+/* line 424, vendor/_normalize.scss */
 td,
 th {
-  padding: 0; }
+  padding: 0;
+}
 
 /* Base */
 /* Colors */
 /* Timing */
+/* line 1, base/_baseline.scss */
 html {
-  box-sizing: border-box; }
+  box-sizing: border-box;
+}
 
+/* line 4, base/_baseline.scss */
 *, *:before, *:after {
-  box-sizing: inherit; }
+  box-sizing: inherit;
+}
 
+/* line 8, base/_baseline.scss */
 html,
 body {
-  height: 100%; }
+  height: 100%;
+}
 
+/* line 13, base/_baseline.scss */
 body {
   font-size: 16px;
   font-family: "Open Sans Regular", "Helvetica Neue", Helvetica, Arial, Sans-serif;
@@ -383,71 +474,98 @@ body {
   text-align: center;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
-  padding-bottom: 4em; }
+  padding-bottom: 4em;
+}
 
+/* line 24, base/_baseline.scss */
 h1 {
   font-family: "Open Sans Bold", "Helvetica Neue", Helvetica, Arial, Sans-serif;
   font-size: 70px;
   font-weight: normal;
   letter-spacing: -1px;
   line-height: 1.13;
-  margin: 37px 0 0 -2px; }
-  h1 span {
-    display: block; }
+  margin: 37px 0 0 -2px;
+}
+/* line 32, base/_baseline.scss */
+h1 span {
+  display: block;
+}
 
+/* line 36, base/_baseline.scss */
 h2 {
   font-size: 42px;
   font-family: "Open Sans Semibold", "Helvetica Neue", Helvetica, Arial, Sans-serif;
   font-weight: normal;
   margin: 0;
-  line-height: normal; }
+  line-height: normal;
+}
 
+/* line 43, base/_baseline.scss */
 .success h3 {
   font-family: 'bt_mono', monospace;
   margin: 0;
-  font-size: 38px; }
+  font-size: 38px;
+}
 
+/* line 49, base/_baseline.scss */
 h6 {
   font-family: 'bt_mono_bold', monospace;
   font-size: 13px;
   font-weight: normal;
-  margin: 0; }
+  margin: 0;
+}
 
+/* line 56, base/_baseline.scss */
 p {
-  margin: 0; }
+  margin: 0;
+}
 
 /* links */
+/* line 61, base/_baseline.scss */
 a,
 a:link,
 a:visited {
-  color: #955AED; }
+  color: #955AED;
+}
 
 /* lists */
+/* line 68, base/_baseline.scss */
 ul {
   list-style: none;
-  padding: 0; }
+  padding: 0;
+}
 
+/* line 72, base/_baseline.scss */
 dl {
   display: block;
   width: 100%;
-  margin: 0; }
-  dl::after {
-    clear: both;
-    content: "";
-    display: table; }
+  margin: 0;
+}
+/* line 20, vendor/bourbon/addons/_clearfix.scss */
+dl::after {
+  clear: both;
+  content: "";
+  display: table;
+}
 
+/* line 78, base/_baseline.scss */
 dt {
   float: left;
   clear: left;
-  width: 20%; }
+  width: 20%;
+}
 
+/* line 83, base/_baseline.scss */
 dd {
   float: left;
   width: 80%;
-  margin: 0; }
+  margin: 0;
+}
 
+/* line 89, base/_baseline.scss */
 pre {
-  margin: 0; }
+  margin: 0;
+}
 
 /*====================================================
 
@@ -458,15 +576,18 @@ pre {
 @font-face {
   font-family: "Avenir Next";
   src: url("../fonts/avenir/4f32268f-fd86-4960-b72c-4bb1ba75ec6f.eot?#iefix");
-  src: url("../fonts/avenir/4f32268f-fd86-4960-b72c-4bb1ba75ec6f.eot?#iefix") format("eot"), url("../fonts/avenir/939cba03-5b40-4d01-9bc5-7589eca863db.woff") format("woff"), url("../fonts/avenir/849bc5b9-a2ff-4343-977b-26ba8bd24a60.ttf") format("truetype"), url("../fonts/avenir/f67fa3b5-c1d1-488f-8e60-a828b9ad56a4.svg#f67fa3b5-c1d1-488f-8e60-a828b9ad56a4") format("svg"); }
+  src: url("../fonts/avenir/4f32268f-fd86-4960-b72c-4bb1ba75ec6f.eot?#iefix") format("eot"), url("../fonts/avenir/939cba03-5b40-4d01-9bc5-7589eca863db.woff") format("woff"), url("../fonts/avenir/849bc5b9-a2ff-4343-977b-26ba8bd24a60.ttf") format("truetype"), url("../fonts/avenir/f67fa3b5-c1d1-488f-8e60-a828b9ad56a4.svg#f67fa3b5-c1d1-488f-8e60-a828b9ad56a4") format("svg");
+}
 @font-face {
   font-family: "Avenir Next Demi";
   src: url("../fonts/avenir/12d643f2-3899-49d5-a85b-ff430f5fad15.eot?#iefix");
-  src: url("../fonts/avenir/12d643f2-3899-49d5-a85b-ff430f5fad15.eot?#iefix") format("eot"), url("../fonts/avenir/91b50bbb-9aa1-4d54-9159-ec6f19d14a7c.woff") format("woff"), url("../fonts/avenir/a0f4c2f9-8a42-4786-ad00-fce42b57b148.ttf") format("truetype"), url("../fonts/avenir/99affa9a-a5e9-4559-bd07-20cf0071852d.svg#99affa9a-a5e9-4559-bd07-20cf0071852d") format("svg"); }
+  src: url("../fonts/avenir/12d643f2-3899-49d5-a85b-ff430f5fad15.eot?#iefix") format("eot"), url("../fonts/avenir/91b50bbb-9aa1-4d54-9159-ec6f19d14a7c.woff") format("woff"), url("../fonts/avenir/a0f4c2f9-8a42-4786-ad00-fce42b57b148.ttf") format("truetype"), url("../fonts/avenir/99affa9a-a5e9-4559-bd07-20cf0071852d.svg#99affa9a-a5e9-4559-bd07-20cf0071852d") format("svg");
+}
 @font-face {
   font-family: "Avenir Next Bold";
   src: url("../fonts/avenir/dccb10af-07a2-404c-bfc7-7750e2716bc1.eot?#iefix");
-  src: url("../fonts/avenir/dccb10af-07a2-404c-bfc7-7750e2716bc1.eot?#iefix") format("eot"), url("../fonts/avenir/b8e906a1-f5e8-4bf1-8e80-82c646ca4d5f.woff") format("woff"), url("../fonts/avenir/890bd988-5306-43ff-bd4b-922bc5ebdeb4.ttf") format("truetype"), url("../fonts/avenir/ed104d8c-7f39-4e8b-90a9-4076be06b857.svg#ed104d8c-7f39-4e8b-90a9-4076be06b857") format("svg"); }
+  src: url("../fonts/avenir/dccb10af-07a2-404c-bfc7-7750e2716bc1.eot?#iefix") format("eot"), url("../fonts/avenir/b8e906a1-f5e8-4bf1-8e80-82c646ca4d5f.woff") format("woff"), url("../fonts/avenir/890bd988-5306-43ff-bd4b-922bc5ebdeb4.ttf") format("truetype"), url("../fonts/avenir/ed104d8c-7f39-4e8b-90a9-4076be06b857.svg#ed104d8c-7f39-4e8b-90a9-4076be06b857") format("svg");
+}
 /*====================================================
 
   Font: Open Sans
@@ -477,19 +598,22 @@ pre {
   src: url("../fonts/open-sans/OpenSans-Regular-webfont.eot");
   src: url("../fonts/open-sans/OpenSans-Regular-webfont.eot?#iefix") format("embedded-opentype"), url("../fonts/open-sans/OpenSans-Regular-webfont.woff") format("woff"), url("../fonts/open-sans/OpenSans-Regular-webfont.ttf") format("truetype"), url("../fonts/open-sans/OpenSans-Regular-webfont.svg#open_sansregular") format("svg");
   font-weight: normal;
-  font-style: normal; }
+  font-style: normal;
+}
 @font-face {
   font-family: 'Open Sans Semibold';
   src: url("../fonts/open-sans/OpenSans-Semibold-webfont.eot");
   src: url("../fonts/open-sans/OpenSans-Semibold-webfont.eot?#iefix") format("embedded-opentype"), url("../fonts/open-sans/OpenSans-Semibold-webfont.woff") format("woff"), url("../fonts/open-sans/OpenSans-Semibold-webfont.ttf") format("truetype"), url("../fonts/open-sans/OpenSans-Semibold-webfont.svg#open_sanssemibold") format("svg");
   font-weight: normal;
-  font-style: normal; }
+  font-style: normal;
+}
 @font-face {
   font-family: 'Open Sans Bold';
   src: url("../fonts/open-sans/OpenSans-Bold-webfont.eot");
   src: url("../fonts/open-sans/OpenSans-Bold-webfont.eot?#iefix") format("embedded-opentype"), url("../fonts/open-sans/OpenSans-Bold-webfont.woff") format("woff"), url("../fonts/open-sans/OpenSans-Bold-webfont.ttf") format("truetype"), url("../fonts/open-sans/OpenSans-Bold-webfont.svg#open_sansbold") format("svg");
   font-weight: normal;
-  font-style: normal; }
+  font-style: normal;
+}
 /*====================================================
 
   Font: BT Mono
@@ -500,20 +624,24 @@ pre {
   src: url("../fonts/bt_mono/bt_mono-Regular.eot");
   src: url("../fonts/bt_mono/bt_mono-Regular.eot?#iefix") format("embedded-opentype"), url("../fonts/bt_mono/bt_mono-Regular.woff2") format("woff2"), url("../fonts/bt_mono/bt_mono-Regular.woff") format("woff"), url("../fonts/bt_mono/bt_mono-Regular.ttf") format("truetype"), url("../fonts/bt_mono/bt_mono-Regular.svg#bt_monoregular") format("svg");
   font-style: normal;
-  font-weight: 400; }
+  font-weight: 400;
+}
 @font-face {
   font-family: 'bt_mono_medium';
   src: url("../fonts/bt_mono/bt_mono-Medium.eot");
   src: url("../fonts/bt_mono/bt_mono-Medium.eot?#iefix") format("embedded-opentype"), url("../fonts/bt_mono/bt_mono-Medium.woff2") format("woff2"), url("../fonts/bt_mono/bt_mono-Medium.woff") format("woff"), url("../fonts/bt_mono/bt_mono-Medium.ttf") format("truetype"), url("../fonts/bt_mono/bt_mono-Medium.svg#bt_monobold") format("svg");
   font-weight: 600;
-  font-style: normal; }
+  font-style: normal;
+}
 @font-face {
   font-family: 'bt_mono_bold';
   src: url("../fonts/bt_mono/bt_mono-Bold.eot");
   src: url("../fonts/bt_mono/bt_mono-Bold.eot?#iefix") format("embedded-opentype"), url("../fonts/bt_mono/bt_mono-Bold.woff2") format("woff2"), url("../fonts/bt_mono/bt_mono-Bold.woff") format("woff"), url("../fonts/bt_mono/bt_mono-Bold.ttf") format("truetype"), url("../fonts/bt_mono/bt_mono-Bold.svg#bt_monobold") format("svg");
   font-weight: 700;
-  font-style: normal; }
+  font-style: normal;
+}
 /* structure */
+/* line 2, base/_layout.scss */
 .container {
   text-align: left;
   margin: 0 auto;
@@ -522,61 +650,89 @@ pre {
   max-width: 65em;
   margin: 0 auto;
   padding: 0 3em;
-  box-sizing: border-box; }
-  .container::after {
-    clear: both;
-    content: "";
-    display: table; }
-  .container > section {
-    padding: 50px;
-    background-color: #fff;
-    border: solid 1px #E3E0E6;
-    position: relative;
-    z-index: 1; }
+  box-sizing: border-box;
+}
+/* line 20, vendor/bourbon/addons/_clearfix.scss */
+.container::after {
+  clear: both;
+  content: "";
+  display: table;
+}
+/* line 13, base/_layout.scss */
+.container > section {
+  padding: 50px;
+  background-color: #fff;
+  border: solid 1px #E3E0E6;
+  position: relative;
+  z-index: 1;
+}
 
+/* line 21, base/_layout.scss */
 .content {
   float: left;
   padding: 40px 60px;
-  text-align: left; }
+  text-align: left;
+}
 
 /* grid */
+/* line 28, base/_layout.scss */
 .row {
   clear: both;
-  width: 100%; }
+  width: 100%;
+}
 
+/* line 32, base/_layout.scss */
 .column {
-  float: left; }
-  .column.half {
-    width: 50%; }
+  float: left;
+}
+/* line 35, base/_layout.scss */
+.column.half {
+  width: 50%;
+}
 
 /* Utilities */
+/* line 1, utilities/_helpers.scss */
 .hide {
-  display: none; }
+  display: none;
+}
 
+/* line 4, utilities/_helpers.scss */
 .center {
-  text-align: center; }
+  text-align: center;
+}
 
+/* line 7, utilities/_helpers.scss */
 .left {
-  float: left; }
+  float: left;
+}
 
+/* line 10, utilities/_helpers.scss */
 .right {
-  float: right; }
+  float: right;
+}
 
-.middle-wrapper, .bar .pane .success-content, .notice .container {
+/* line 13, utilities/_helpers.scss */
+.middle-wrapper, .bar .pane .success-content, .bar .pane .error-content, .notice .container {
   display: table;
   width: 100%;
-  height: 100%; }
+  height: 100%;
+}
 
-.middle, .bar .pane .success-middle, .notice p {
+/* line 18, utilities/_helpers.scss */
+.middle, .bar .pane .success-middle, .bar .pane .error-middle, .notice p {
   display: table-cell;
   vertical-align: middle;
-  padding: 1em 0 1em; }
+  padding: 1em 0 1em;
+}
 
+/* line 23, utilities/_helpers.scss */
 .pseudo-element, .button:before, .button:after {
   content: '';
-  display: block; }
+  display: block;
+}
 
 /* Components */
+/* line 3, components/_bar.scss */
 .bar {
   position: fixed;
   bottom: 0;
@@ -584,184 +740,313 @@ pre {
   text-align: center;
   width: 100%;
   height: 54px;
-  z-index: 99; }
-  .bar .container {
-    height: 100%; }
-  .bar ul,
-  .bar ul > li {
-    display: inline-block;
-    height: 54px;
-    float: left; }
-  .bar ul {
-    float: right;
-    margin: 0; }
-    .signup .bar ul {
-      background-color: #fff; }
-  .bar .button {
-    background-color: #2CA1E9;
-    border-radius: 0px;
-    width: 100%;
-    text-align: center;
-    margin-top: 1.5em; }
-    .bar .button:hover, .bar .button:focus {
-      background-color: #168dd6; }
+  z-index: 99;
+}
+/* line 12, components/_bar.scss */
+.bar .container {
+  height: 100%;
+}
+/* line 16, components/_bar.scss */
+.bar ul,
+.bar ul > li {
+  display: inline-block;
+  height: 54px;
+  float: left;
+}
+/* line 23, components/_bar.scss */
+.bar ul {
+  float: right;
+  margin: 0;
+}
+/* line 27, components/_bar.scss */
+.signup .bar ul {
+  background-color: #fff;
+}
+/* line 32, components/_bar.scss */
+.bar .button {
+  background-color: #2CA1E9;
+  border-radius: 0px;
+  width: 100%;
+  text-align: center;
+  margin-top: 1.5em;
+}
+/* line 39, components/_bar.scss */
+.bar .button:hover, .bar .button:focus {
+  background-color: #168dd6;
+}
 
+/* line 46, components/_bar.scss */
 .bar .pane {
   height: auto;
   max-width: 500px;
   position: relative;
   -webkit-transition: -webkit-transform 0.4s cubic-bezier(0.645, 0.045, 0.355, 1), box-shadow 0.4s linear;
   -moz-transition: -moz-transform 0.4s cubic-bezier(0.645, 0.045, 0.355, 1), box-shadow 0.4s linear;
-  transition: transform 0.4s cubic-bezier(0.645, 0.045, 0.355, 1), box-shadow 0.4s linear; }
-  .bar .pane section {
-    clear: both;
-    position: relative; }
-  .bar .pane .success {
-    position: absolute;
-    background-color: #fff;
-    width: 100%;
-    height: 100%;
-    left: 0px;
-    top: 100%;
-    z-index: 2;
-    text-align: center;
-    opacity: 0;
-    -webkit-transition: opacity 0.4s ease-in-out;
-    -moz-transition: opacity 0.4s ease-in-out;
-    transition: opacity 0.4s ease-in-out; }
-    .bar .pane .success h3,
-    .bar .pane .success p,
-    .bar .pane .success .icon {
-      opacity: 0;
-      -webkit-transform: translateY(100px);
-      -moz-transform: translateY(100px);
-      -ms-transform: translateY(100px);
-      -o-transform: translateY(100px);
-      transform: translateY(100px);
-      -webkit-transition: -webkit-transform 0.4s cubic-bezier(0.165, 0.84, 0.44, 1), opacity 0.4s ease;
-      -moz-transition: -moz-transform 0.4s cubic-bezier(0.165, 0.84, 0.44, 1), opacity 0.4s ease;
-      transition: transform 0.4s cubic-bezier(0.165, 0.84, 0.44, 1), opacity 0.4s ease; }
-    .bar .pane .success.show {
-      opacity: 1;
-      top: 0%; }
-      .bar .pane .success.show h3,
-      .bar .pane .success.show p,
-      .bar .pane .success.show .icon {
-        opacity: 1;
-        -webkit-transform: translateY(0px);
-        -moz-transform: translateY(0px);
-        -ms-transform: translateY(0px);
-        -o-transform: translateY(0px);
-        transform: translateY(0px); }
-      .bar .pane .success.show h3 {
-        -webkit-transition-delay: 0.1s;
-        -moz-transition-delay: 0.1s;
-        transition-delay: 0.1s; }
-      .bar .pane .success.show p {
-        -webkit-transition-delay: 0.2s;
-        -moz-transition-delay: 0.2s;
-        transition-delay: 0.2s; }
-  .bar .pane .icon-success {
-    background: url(../images/icons/icon-success.svg) center center no-repeat transparent;
-    display: inline-block;
-    width: 50px;
-    height: 50px;
-    margin-top: -60px; }
-  .bar .pane a.toggle {
-    -webkit-transition: background-color 0.4s linear, color 0.4s linear, width 0.2s cubic-bezier(0.77, 0, 0.175, 1), opacity 0.2s ease;
-    -moz-transition: background-color 0.4s linear, color 0.4s linear, width 0.2s cubic-bezier(0.77, 0, 0.175, 1), opacity 0.2s ease;
-    transition: background-color 0.4s linear, color 0.4s linear, width 0.2s cubic-bezier(0.77, 0, 0.175, 1), opacity 0.2s ease;
-    font-family: 'bt_mono_medium', monospace;
-    font-size: 15px;
-    background-color: #F7F6F8;
-    color: #3E3C41;
-    display: block;
-    float: right;
-    width: auto;
-    text-decoration: none;
-    height: 54px;
-    line-height: 54px;
-    padding: 0 30px;
-    text-align: left;
-    position: relative; }
-    .bar .pane a.toggle:hover {
-      opacity: .9; }
-    .bar .pane a.toggle:after {
-      content: '+';
-      position: absolute;
-      right: 30px;
-      top: 50%;
-      line-height: normal;
-      margin-top: -8px; }
-  .bar .pane .title,
-  .bar .pane .detail {
-    display: inline-block;
-    height: 54px;
-    line-height: 54px; }
-  .bar .pane .title {
-    padding-right: 15px;
-    position: relative; }
-  .bar .pane .detail {
-    -webkit-transition: opacity 0.4s ease;
-    -moz-transition: opacity 0.4s ease;
-    transition: opacity 0.4s ease;
-    opacity: 0;
-    position: absolute;
-    left: 100%;
-    top: 0px; }
-  .bar .pane.open {
-    box-shadow: 0px 0px 14px rgba(0, 0, 0, 0.14), 0px 0px 3px rgba(0, 0, 0, 0.14); }
-    .bar .pane.open a.toggle {
-      background-color: #3E3C41;
-      color: #fff; }
-      .bar .pane.open a.toggle:after {
-        content: '-'; }
-    .bar .pane.open .detail {
-      opacity: .6; }
-  .bar .pane .pane-content {
-    background-color: #fff;
-    padding: 30px;
-    width: 100%;
-    position: relative;
-    z-index: 1; }
+  transition: transform 0.4s cubic-bezier(0.645, 0.045, 0.355, 1), box-shadow 0.4s linear;
+}
+/* line 53, components/_bar.scss */
+.bar .pane section {
+  clear: both;
+  position: relative;
+}
+/* line 58, components/_bar.scss */
+.bar .pane .success {
+  position: absolute;
+  background-color: #fff;
+  width: 100%;
+  height: 100%;
+  left: 0px;
+  top: 100%;
+  z-index: 2;
+  text-align: center;
+  opacity: 0;
+  -webkit-transition: opacity 0.4s ease-in-out;
+  -moz-transition: opacity 0.4s ease-in-out;
+  transition: opacity 0.4s ease-in-out;
+}
+/* line 70, components/_bar.scss */
+.bar .pane .success h3,
+.bar .pane .success p,
+.bar .pane .success .icon {
+  opacity: 0;
+  -webkit-transform: translateY(100px);
+  -moz-transform: translateY(100px);
+  -ms-transform: translateY(100px);
+  -o-transform: translateY(100px);
+  transform: translateY(100px);
+  -webkit-transition: -webkit-transform 0.4s cubic-bezier(0.165, 0.84, 0.44, 1), opacity 0.4s ease;
+  -moz-transition: -moz-transform 0.4s cubic-bezier(0.165, 0.84, 0.44, 1), opacity 0.4s ease;
+  transition: transform 0.4s cubic-bezier(0.165, 0.84, 0.44, 1), opacity 0.4s ease;
+}
+/* line 78, components/_bar.scss */
+.bar .pane .success.show {
+  opacity: 1;
+  top: 0%;
+}
+/* line 82, components/_bar.scss */
+.bar .pane .success.show h3,
+.bar .pane .success.show p,
+.bar .pane .success.show .icon {
+  opacity: 1;
+  -webkit-transform: translateY(0px);
+  -moz-transform: translateY(0px);
+  -ms-transform: translateY(0px);
+  -o-transform: translateY(0px);
+  transform: translateY(0px);
+}
+/* line 89, components/_bar.scss */
+.bar .pane .success.show h3 {
+  -webkit-transition-delay: 0.1s;
+  -moz-transition-delay: 0.1s;
+  transition-delay: 0.1s;
+}
+/* line 93, components/_bar.scss */
+.bar .pane .success.show p {
+  -webkit-transition-delay: 0.2s;
+  -moz-transition-delay: 0.2s;
+  transition-delay: 0.2s;
+}
+/* line 107, components/_bar.scss */
+.bar .pane .icon-success {
+  background: url(../images/icons/icon-success.svg) center center no-repeat transparent;
+  display: inline-block;
+  width: 50px;
+  height: 50px;
+  margin-top: -60px;
+}
+/* line 115, components/_bar.scss */
+.bar .pane .error {
+  position: absolute;
+  background-color: #fff;
+  width: 100%;
+  height: 100%;
+  left: 0px;
+  top: 100%;
+  z-index: 2;
+  text-align: center;
+  opacity: 0;
+  -webkit-transition: opacity 0.4s ease-in-out;
+  -moz-transition: opacity 0.4s ease-in-out;
+  transition: opacity 0.4s ease-in-out;
+}
+/* line 127, components/_bar.scss */
+.bar .pane .error h3,
+.bar .pane .error p,
+.bar .pane .error .icon {
+  opacity: 0;
+  -webkit-transform: translateY(100px);
+  -moz-transform: translateY(100px);
+  -ms-transform: translateY(100px);
+  -o-transform: translateY(100px);
+  transform: translateY(100px);
+  -webkit-transition: -webkit-transform 0.4s cubic-bezier(0.165, 0.84, 0.44, 1), opacity 0.4s ease;
+  -moz-transition: -moz-transform 0.4s cubic-bezier(0.165, 0.84, 0.44, 1), opacity 0.4s ease;
+  transition: transform 0.4s cubic-bezier(0.165, 0.84, 0.44, 1), opacity 0.4s ease;
+}
+/* line 135, components/_bar.scss */
+.bar .pane .error.show {
+  opacity: 1;
+  top: 0%;
+}
+/* line 139, components/_bar.scss */
+.bar .pane .error.show h3,
+.bar .pane .error.show p,
+.bar .pane .error.show .icon {
+  opacity: 1;
+  -webkit-transform: translateY(0px);
+  -moz-transform: translateY(0px);
+  -ms-transform: translateY(0px);
+  -o-transform: translateY(0px);
+  transform: translateY(0px);
+}
+/* line 146, components/_bar.scss */
+.bar .pane .error.show h3 {
+  -webkit-transition-delay: 0.1s;
+  -moz-transition-delay: 0.1s;
+  transition-delay: 0.1s;
+}
+/* line 150, components/_bar.scss */
+.bar .pane .error.show p {
+  -webkit-transition-delay: 0.2s;
+  -moz-transition-delay: 0.2s;
+  transition-delay: 0.2s;
+}
+/* line 164, components/_bar.scss */
+.bar .pane a.toggle {
+  -webkit-transition: background-color 0.4s linear, color 0.4s linear, width 0.2s cubic-bezier(0.77, 0, 0.175, 1), opacity 0.2s ease;
+  -moz-transition: background-color 0.4s linear, color 0.4s linear, width 0.2s cubic-bezier(0.77, 0, 0.175, 1), opacity 0.2s ease;
+  transition: background-color 0.4s linear, color 0.4s linear, width 0.2s cubic-bezier(0.77, 0, 0.175, 1), opacity 0.2s ease;
+  font-family: 'bt_mono_medium', monospace;
+  font-size: 15px;
+  background-color: #F7F6F8;
+  color: #3E3C41;
+  display: block;
+  float: right;
+  width: auto;
+  text-decoration: none;
+  height: 54px;
+  line-height: 54px;
+  padding: 0 30px;
+  text-align: left;
+  position: relative;
+}
+/* line 180, components/_bar.scss */
+.bar .pane a.toggle:hover {
+  opacity: .9;
+}
+/* line 184, components/_bar.scss */
+.bar .pane a.toggle:after {
+  content: '+';
+  position: absolute;
+  right: 30px;
+  top: 50%;
+  line-height: normal;
+  margin-top: -8px;
+}
+/* line 194, components/_bar.scss */
+.bar .pane .title,
+.bar .pane .detail {
+  display: inline-block;
+  height: 54px;
+  line-height: 54px;
+}
+/* line 201, components/_bar.scss */
+.bar .pane .title {
+  padding-right: 15px;
+  position: relative;
+}
+/* line 206, components/_bar.scss */
+.bar .pane .detail {
+  -webkit-transition: opacity 0.4s ease;
+  -moz-transition: opacity 0.4s ease;
+  transition: opacity 0.4s ease;
+  opacity: 0;
+  position: absolute;
+  left: 100%;
+  top: 0px;
+}
+/* line 214, components/_bar.scss */
+.bar .pane.open {
+  box-shadow: 0px 0px 14px rgba(0, 0, 0, 0.14), 0px 0px 3px rgba(0, 0, 0, 0.14);
+}
+/* line 217, components/_bar.scss */
+.bar .pane.open a.toggle {
+  background-color: #3E3C41;
+  color: #fff;
+}
+/* line 221, components/_bar.scss */
+.bar .pane.open a.toggle:after {
+  content: '-';
+}
+/* line 226, components/_bar.scss */
+.bar .pane.open .detail {
+  opacity: .6;
+}
+/* line 231, components/_bar.scss */
+.bar .pane .pane-content {
+  background-color: #fff;
+  padding: 30px;
+  width: 100%;
+  position: relative;
+  z-index: 1;
+}
 
+/* line 240, components/_bar.scss */
 .credentials {
   background-color: #f9f9f9;
   padding: 25px 15px;
   list-style: none;
-  border-bottom: solid 1px #CAC6CE; }
-  .credentials::after {
-    clear: both;
-    content: "";
-    display: table; }
-  .credentials li {
-    width: 50%;
-    padding: 0 15px;
-    float: left; }
-  .credentials p {
-    font-family: 'bt_mono', monospace;
-    font-size: 13px; }
+  border-bottom: solid 1px #CAC6CE;
+}
+/* line 20, vendor/bourbon/addons/_clearfix.scss */
+.credentials::after {
+  clear: both;
+  content: "";
+  display: table;
+}
+/* line 247, components/_bar.scss */
+.credentials li {
+  width: 50%;
+  padding: 0 15px;
+  float: left;
+}
+/* line 253, components/_bar.scss */
+.credentials p {
+  font-family: 'bt_mono', monospace;
+  font-size: 13px;
+}
 
+/* line 259, components/_bar.scss */
 .braintree {
-  background-color: #3E3C41; }
-  .braintree nav {
-    float: left; }
-    .braintree nav,
-    .braintree nav ul,
-    .braintree nav li {
-      display: inline-block;
-      height: 54px;
-      line-height: 54px; }
-    .braintree nav li {
-      margin-right: 1.5em; }
-    .braintree nav a {
-      text-decoration: none;
-      color: #fff;
-      display: block;
-      line-height: 54px;
-      font-size: 14px;
-      font-family: "bt_mono_bold", monospace; }
+  background-color: #3E3C41;
+}
+/* line 262, components/_bar.scss */
+.braintree nav {
+  float: left;
+}
+/* line 265, components/_bar.scss */
+.braintree nav,
+.braintree nav ul,
+.braintree nav li {
+  display: inline-block;
+  height: 54px;
+  line-height: 54px;
+}
+/* line 273, components/_bar.scss */
+.braintree nav li {
+  margin-right: 1.5em;
+}
+/* line 277, components/_bar.scss */
+.braintree nav a {
+  text-decoration: none;
+  color: #fff;
+  display: block;
+  line-height: 54px;
+  font-size: 14px;
+  font-family: "bt_mono_bold", monospace;
+}
 
+/* line 288, components/_bar.scss */
 .braintree-auth {
   float: left;
   background: url(../images/braintree_auth.svg) center center no-repeat transparent;
@@ -769,20 +1054,28 @@ pre {
   overflow: hidden;
   width: 200px;
   height: 100%;
-  text-indent: -999em; }
+  text-indent: -999em;
+}
 
+/* line 1, components/_brand.scss */
 .company {
   font-family: "Open Sans Regular", "Helvetica Neue", Helvetica, Arial, Sans-serif;
-  font-size: 21px; }
-  .company span {
-    font-family: "Open Sans Semibold", "Helvetica Neue", Helvetica, Arial, Sans-serif; }
-  header .company {
-    color: #fff;
-    font-size: 21px;
-    float: left;
-    position: absolute;
-    z-index: 999; }
+  font-size: 21px;
+}
+/* line 5, components/_brand.scss */
+.company span {
+  font-family: "Open Sans Semibold", "Helvetica Neue", Helvetica, Arial, Sans-serif;
+}
+/* line 10, components/_brand.scss */
+header .company {
+  color: #fff;
+  font-size: 21px;
+  float: left;
+  position: absolute;
+  z-index: 999;
+}
 
+/* line 1, components/_buttons.scss */
 .button {
   display: block;
   background-color: #955AED;
@@ -800,100 +1093,133 @@ pre {
   position: relative;
   -webkit-transition: background-color 0.1s linear;
   -moz-transition: background-color 0.1s linear;
-  transition: background-color 0.1s linear; }
-  .signup .button {
-    border-radius: 0px 3px 3px 0px;
-    position: relative;
-    z-index: 2; }
-  .button em {
-    background: url(../images/icons/arrow-right.svg) center center no-repeat #a471f0;
-    display: inline-block;
-    width: 24px;
-    height: 24px;
-    margin: 0 0 0 14px;
-    position: relative;
-    top: 6px;
-    border-radius: 50%; }
-  .button span {
-    display: inline-block;
-    -webkit-transform: translateY(0%);
-    -moz-transform: translateY(0%);
-    -ms-transform: translateY(0%);
-    -o-transform: translateY(0%);
-    transform: translateY(0%);
-    -webkit-transition: -webkit-transform 0.4s cubic-bezier(0.77, 0, 0.175, 1);
-    -moz-transition: -moz-transform 0.4s cubic-bezier(0.77, 0, 0.175, 1);
-    transition: transform 0.4s cubic-bezier(0.77, 0, 0.175, 1); }
-  .button:focus {
-    background-color: #7d35e9; }
-  .button:hover, .button:active {
-    background-color: #8948eb; }
-  .button:before, .button:after {
-    width: 22px;
-    height: 22px;
-    border-radius: 50%;
-    position: absolute;
-    left: 50%;
-    top: 50%;
-    margin: -11px 0 0 -11px;
-    border: solid 1px rgba(0, 0, 0, 0.2);
-    -webkit-transform: translateY(200px);
-    -moz-transform: translateY(200px);
-    -ms-transform: translateY(200px);
-    -o-transform: translateY(200px);
-    transform: translateY(200px);
-    -webkit-transition: -webkit-transform 0.4s cubic-bezier(0.77, 0, 0.175, 1);
-    -moz-transition: -moz-transform 0.4s cubic-bezier(0.77, 0, 0.175, 1);
-    transition: transform 0.4s cubic-bezier(0.77, 0, 0.175, 1); }
-  .button:after {
-    border-color: transparent;
-    border-top-color: #fff; }
-  .button.loading span {
-    -webkit-transform: translateY(-200px);
-    -moz-transform: translateY(-200px);
-    -ms-transform: translateY(-200px);
-    -o-transform: translateY(-200px);
-    transform: translateY(-200px); }
-  .button.loading:before, .button.loading:after {
-    -webkit-transform: translateY(0px);
-    -moz-transform: translateY(0px);
-    -ms-transform: translateY(0px);
-    -o-transform: translateY(0px);
-    transform: translateY(0px); }
-  .button.loading:after {
-    -webkit-animation: spin 0.44s cubic-bezier(0.445, 0.05, 0.55, 0.95);
-    -moz-animation: spin 0.44s cubic-bezier(0.445, 0.05, 0.55, 0.95);
-    animation: spin 0.44s cubic-bezier(0.445, 0.05, 0.55, 0.95);
-    -webkit-animation-iteration-count: infinite;
-    -moz-animation-iteration-count: infinite;
-    animation-iteration-count: infinite; }
+  transition: background-color 0.1s linear;
+}
+/* line 18, components/_buttons.scss */
+.signup .button {
+  border-radius: 0px 3px 3px 0px;
+  position: relative;
+  z-index: 2;
+}
+/* line 24, components/_buttons.scss */
+.button em {
+  background: url(../images/icons/arrow-right.svg) center center no-repeat #a471f0;
+  display: inline-block;
+  width: 24px;
+  height: 24px;
+  margin: 0 0 0 14px;
+  position: relative;
+  top: 6px;
+  border-radius: 50%;
+}
+/* line 35, components/_buttons.scss */
+.button span {
+  display: inline-block;
+  -webkit-transform: translateY(0%);
+  -moz-transform: translateY(0%);
+  -ms-transform: translateY(0%);
+  -o-transform: translateY(0%);
+  transform: translateY(0%);
+  -webkit-transition: -webkit-transform 0.4s cubic-bezier(0.77, 0, 0.175, 1);
+  -moz-transition: -moz-transform 0.4s cubic-bezier(0.77, 0, 0.175, 1);
+  transition: transform 0.4s cubic-bezier(0.77, 0, 0.175, 1);
+}
+/* line 41, components/_buttons.scss */
+.button:focus {
+  background-color: #7d35e9;
+}
+/* line 45, components/_buttons.scss */
+.button:hover, .button:active {
+  background-color: #8948eb;
+}
+/* line 50, components/_buttons.scss */
+.button:before, .button:after {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  margin: -11px 0 0 -11px;
+  border: solid 1px rgba(0, 0, 0, 0.2);
+  -webkit-transform: translateY(200px);
+  -moz-transform: translateY(200px);
+  -ms-transform: translateY(200px);
+  -o-transform: translateY(200px);
+  transform: translateY(200px);
+  -webkit-transition: -webkit-transform 0.4s cubic-bezier(0.77, 0, 0.175, 1);
+  -moz-transition: -moz-transform 0.4s cubic-bezier(0.77, 0, 0.175, 1);
+  transition: transform 0.4s cubic-bezier(0.77, 0, 0.175, 1);
+}
+/* line 65, components/_buttons.scss */
+.button:after {
+  border-color: transparent;
+  border-top-color: #fff;
+}
+/* line 71, components/_buttons.scss */
+.button.loading span {
+  -webkit-transform: translateY(-200px);
+  -moz-transform: translateY(-200px);
+  -ms-transform: translateY(-200px);
+  -o-transform: translateY(-200px);
+  transform: translateY(-200px);
+}
+/* line 75, components/_buttons.scss */
+.button.loading:before, .button.loading:after {
+  -webkit-transform: translateY(0px);
+  -moz-transform: translateY(0px);
+  -ms-transform: translateY(0px);
+  -o-transform: translateY(0px);
+  transform: translateY(0px);
+}
+/* line 80, components/_buttons.scss */
+.button.loading:after {
+  -webkit-animation: spin 0.44s cubic-bezier(0.445, 0.05, 0.55, 0.95);
+  -moz-animation: spin 0.44s cubic-bezier(0.445, 0.05, 0.55, 0.95);
+  animation: spin 0.44s cubic-bezier(0.445, 0.05, 0.55, 0.95);
+  -webkit-animation-iteration-count: infinite;
+  -moz-animation-iteration-count: infinite;
+  animation-iteration-count: infinite;
+}
 
 @-webkit-keyframes spin {
   from {
-    -webkit-transform: rotate(0deg); }
+    -webkit-transform: rotate(0deg);
+  }
   to {
-    -webkit-transform: rotate(360deg); } }
+    -webkit-transform: rotate(360deg);
+  }
+}
 @-moz-keyframes spin {
   from {
-    -moz-transform: rotate(0deg); }
+    -moz-transform: rotate(0deg);
+  }
   to {
-    -moz-transform: rotate(360deg); } }
+    -moz-transform: rotate(360deg);
+  }
+}
 @keyframes spin {
   from {
     -webkit-transform: rotate(0deg);
     -moz-transform: rotate(0deg);
     -ms-transform: rotate(0deg);
     -o-transform: rotate(0deg);
-    transform: rotate(0deg); }
+    transform: rotate(0deg);
+  }
   to {
     -webkit-transform: rotate(360deg);
     -moz-transform: rotate(360deg);
     -ms-transform: rotate(360deg);
     -o-transform: rotate(360deg);
-    transform: rotate(360deg); } }
+    transform: rotate(360deg);
+  }
+}
+/* line 2, components/_form.scss */
 .signup form {
   display: block;
-  width: 100%; }
+  width: 100%;
+}
+/* line 7, components/_form.scss */
 .signup label {
   border-radius: 3px 0px 0px 3px;
   display: block;
@@ -904,31 +1230,47 @@ pre {
   z-index: 1;
   -webkit-transition: border-color 0.3s ease;
   -moz-transition: border-color 0.3s ease;
-  transition: border-color 0.3s ease; }
-  .signup .signup label {
-    border-right: none;
-    border-radius: 3px 0px 0px 3px; }
-  .signup label:hover {
-    border-color: #707073; }
-  .signup label span,
-  .signup label input {
-    border: none;
-    float: left;
-    display: inline-block;
-    height: 48px;
-    line-height: 48px; }
-  .signup label input {
-    padding: 0;
-    -webkit-transition: color 0.3s ease;
-    -moz-transition: color 0.3s ease;
-    transition: color 0.3s ease; }
-  .signup label span {
-    font-family: "Open Sans Semibold", "Helvetica Neue", Helvetica, Arial, Sans-serif;
-    padding: 0 20px; }
-  .signup label.has-focus {
-    border-color: #955AED; }
-    .signup label.has-focus input {
-      color: #955AED; }
+  transition: border-color 0.3s ease;
+}
+/* line 18, components/_form.scss */
+.signup .signup label {
+  border-right: none;
+  border-radius: 3px 0px 0px 3px;
+}
+/* line 23, components/_form.scss */
+.signup label:hover {
+  border-color: #707073;
+}
+/* line 27, components/_form.scss */
+.signup label span,
+.signup label input {
+  border: none;
+  float: left;
+  display: inline-block;
+  height: 48px;
+  line-height: 48px;
+}
+/* line 36, components/_form.scss */
+.signup label input {
+  padding: 0;
+  -webkit-transition: color 0.3s ease;
+  -moz-transition: color 0.3s ease;
+  transition: color 0.3s ease;
+}
+/* line 41, components/_form.scss */
+.signup label span {
+  font-family: "Open Sans Semibold", "Helvetica Neue", Helvetica, Arial, Sans-serif;
+  padding: 0 20px;
+}
+/* line 46, components/_form.scss */
+.signup label.has-focus {
+  border-color: #955AED;
+}
+/* line 49, components/_form.scss */
+.signup label.has-focus input {
+  color: #955AED;
+}
+/* line 55, components/_form.scss */
 .signup input[type=text],
 .signup input[type=email],
 .signup select {
@@ -940,53 +1282,69 @@ pre {
   outline: none;
   -webkit-transition: border-color 0.1s linear, box-shadow 0.1s linear;
   -moz-transition: border-color 0.1s linear, box-shadow 0.1s linear;
-  transition: border-color 0.1s linear, box-shadow 0.1s linear; }
-  .signup input[type=text]:hover,
-  .signup input[type=email]:hover,
-  .signup select:hover {
-    border-color: #707073; }
-  .signup input[type=text]:focus,
-  .signup input[type=email]:focus,
-  .signup select:focus {
-    border-color: #3E3C41; }
+  transition: border-color 0.1s linear, box-shadow 0.1s linear;
+}
+/* line 66, components/_form.scss */
+.signup input[type=text]:hover,
+.signup input[type=email]:hover,
+.signup select:hover {
+  border-color: #707073;
+}
+/* line 70, components/_form.scss */
+.signup input[type=text]:focus,
+.signup input[type=email]:focus,
+.signup select:focus {
+  border-color: #3E3C41;
+}
+/* line 74, components/_form.scss */
 .signup input,
 .signup select {
   font-size: 17px;
-  pointer-events: auto; }
+  pointer-events: auto;
+}
+/* line 80, components/_form.scss */
 .signup .select-container {
   position: relative;
-  pointer-events: none; }
-  .signup .select-container select {
-    height: 60px;
-    line-height: 60px;
-    color: #3E3C41;
-    cursor: pointer;
-    border: 0;
-    padding: 0 40px 0 30px; }
-  .signup .select-container:after {
-    content: "";
-    display: block;
-    width: 0px;
-    height: 0px;
-    font-size: 0px;
-    line-height: 0px;
-    border-top: solid 5px #3E3C41;
-    border-left: solid 3px transparent;
-    border-right: solid 3px transparent;
-    position: absolute;
-    right: 27px;
-    top: 50%;
-    -webkit-transform: translateY(0.5px);
-    -moz-transform: translateY(0.5px);
-    -ms-transform: translateY(0.5px);
-    -o-transform: translateY(0.5px);
-    transform: translateY(0.5px);
-    margin-top: -3px; }
+  pointer-events: none;
+}
+/* line 84, components/_form.scss */
+.signup .select-container select {
+  height: 60px;
+  line-height: 60px;
+  color: #3E3C41;
+  cursor: pointer;
+  border: 0;
+  padding: 0 40px 0 30px;
+}
+/* line 93, components/_form.scss */
+.signup .select-container:after {
+  content: "";
+  display: block;
+  width: 0px;
+  height: 0px;
+  font-size: 0px;
+  line-height: 0px;
+  border-top: solid 5px #3E3C41;
+  border-left: solid 3px transparent;
+  border-right: solid 3px transparent;
+  position: absolute;
+  right: 27px;
+  top: 50%;
+  -webkit-transform: translateY(0.5px);
+  -moz-transform: translateY(0.5px);
+  -ms-transform: translateY(0.5px);
+  -o-transform: translateY(0.5px);
+  transform: translateY(0.5px);
+  margin-top: -3px;
+}
 
+/* line 113, components/_form.scss */
 .bar select {
   font-family: "bt_mono_medium", monospace;
   font-size: 15px;
-  margin-top: -3px; }
+  margin-top: -3px;
+}
+/* line 119, components/_form.scss */
 .bar label {
   display: block;
   width: 100%;
@@ -994,7 +1352,9 @@ pre {
   border-bottom: solid 1px #e0e0e0;
   position: relative;
   margin-bottom: -1px;
-  z-index: 1; }
+  z-index: 1;
+}
+/* line 129, components/_form.scss */
 .bar .label,
 .bar .input:after {
   font-family: "bt_mono_bold", monospace;
@@ -1002,7 +1362,9 @@ pre {
   position: absolute;
   left: 15px;
   font-size: 13px;
-  z-index: 3; }
+  z-index: 3;
+}
+/* line 139, components/_form.scss */
 .bar .input {
   padding: 33px 20px 13px 12px;
   font-size: 16px;
@@ -1011,49 +1373,67 @@ pre {
   -webkit-transition: border-color 0.2s ease, background-color 0.2s ease;
   -moz-transition: border-color 0.2s ease, background-color 0.2s ease;
   transition: border-color 0.2s ease, background-color 0.2s ease;
-  position: relative; }
-  .bar .input:after, .bar .input:before {
-    content: "";
-    position: absolute;
-    right: 15px;
-    left: auto;
-    color: #ed574a;
-    opacity: 0;
-    -webkit-transform: translateY(10px);
-    -moz-transform: translateY(10px);
-    -ms-transform: translateY(10px);
-    -o-transform: translateY(10px);
-    transform: translateY(10px);
-    -webkit-transition: -webkit-transform 0.2s cubic-bezier(0.165, 0.84, 0.44, 1), opacity 0.2s ease;
-    -moz-transition: -moz-transform 0.2s cubic-bezier(0.165, 0.84, 0.44, 1), opacity 0.2s ease;
-    transition: transform 0.2s cubic-bezier(0.165, 0.84, 0.44, 1), opacity 0.2s ease; }
-  .bar .input:before {
-    background: url(../images/icons/icon-check-green.svg) left top no-repeat transparent;
-    display: block;
-    width: 12px;
-    height: 9px;
-    top: 17px; }
-  .bar .input:after {
-    content: 'required'; }
-  .bar .input.braintree-hosted-fields-invalid:after, .bar .input.braintree-hosted-fields-valid:before {
-    -webkit-transform: translateY(0px);
-    -moz-transform: translateY(0px);
-    -ms-transform: translateY(0px);
-    -o-transform: translateY(0px);
-    transform: translateY(0px);
-    opacity: 1; }
+  position: relative;
+}
+/* line 147, components/_form.scss */
+.bar .input:after, .bar .input:before {
+  content: "";
+  position: absolute;
+  right: 15px;
+  left: auto;
+  color: #ed574a;
+  opacity: 0;
+  -webkit-transform: translateY(10px);
+  -moz-transform: translateY(10px);
+  -ms-transform: translateY(10px);
+  -o-transform: translateY(10px);
+  transform: translateY(10px);
+  -webkit-transition: -webkit-transform 0.2s cubic-bezier(0.165, 0.84, 0.44, 1), opacity 0.2s ease;
+  -moz-transition: -moz-transform 0.2s cubic-bezier(0.165, 0.84, 0.44, 1), opacity 0.2s ease;
+  transition: transform 0.2s cubic-bezier(0.165, 0.84, 0.44, 1), opacity 0.2s ease;
+}
+/* line 159, components/_form.scss */
+.bar .input:before {
+  background: url(../images/icons/icon-check-green.svg) left top no-repeat transparent;
+  display: block;
+  width: 12px;
+  height: 9px;
+  top: 17px;
+}
+/* line 167, components/_form.scss */
+.bar .input:after {
+  content: 'required';
+}
+/* line 171, components/_form.scss */
+.bar .input.braintree-hosted-fields-invalid:after, .bar .input.braintree-hosted-fields-valid:before {
+  -webkit-transform: translateY(0px);
+  -moz-transform: translateY(0px);
+  -ms-transform: translateY(0px);
+  -o-transform: translateY(0px);
+  transform: translateY(0px);
+  opacity: 1;
+}
+/* line 178, components/_form.scss */
 .bar .braintree-hosted-fields-invalid {
-  border-left-color: #ed574a; }
+  border-left-color: #ed574a;
+}
+/* line 182, components/_form.scss */
 .bar .braintree-hosted-fields-focused {
   background-color: #FAFDFF;
-  border-left-color: #2CA1E9; }
+  border-left-color: #2CA1E9;
+}
 
+/* line 188, components/_form.scss */
 #paypalContainer {
-  margin-bottom: 1.5em; }
+  margin-bottom: 1.5em;
+}
 
+/* line 192, components/_form.scss */
 .paypal-button-tag-content {
-  display: none; }
+  display: none;
+}
 
+/* line 1, components/_inline-messages.scss */
 .notice {
   background-color: #955AED;
   color: #fff;
@@ -1074,34 +1454,46 @@ pre {
   transform: translateY(-100%);
   height: 80px;
   line-height: 80px;
-  z-index: 4; }
-  .notice.show {
-    -webkit-transform: translateY(0%);
-    -moz-transform: translateY(0%);
-    -ms-transform: translateY(0%);
-    -o-transform: translateY(0%);
-    transform: translateY(0%); }
-  .notice .container {
-    text-align: center; }
-  .container .notice {
-    height: auto;
-    line-height: 46px;
-    margin-bottom: -1px; }
-  .notice p {
-    margin: 0 auto;
-    text-align: center;
-    line-height: 1.4;
-    padding: 0 140px; }
-  .notice em {
-    background: url(../images/tick.svg) center center no-repeat #a471f0;
-    display: inline-block;
-    margin-right: 1em;
-    width: 28px;
-    height: 28px;
-    border-radius: 50%;
-    position: relative;
-    top: 8px; }
+  z-index: 4;
+}
+/* line 17, components/_inline-messages.scss */
+.notice.show {
+  -webkit-transform: translateY(0%);
+  -moz-transform: translateY(0%);
+  -ms-transform: translateY(0%);
+  -o-transform: translateY(0%);
+  transform: translateY(0%);
+}
+/* line 21, components/_inline-messages.scss */
+.notice .container {
+  text-align: center;
+}
+/* line 26, components/_inline-messages.scss */
+.container .notice {
+  height: auto;
+  line-height: 46px;
+  margin-bottom: -1px;
+}
+/* line 32, components/_inline-messages.scss */
+.notice p {
+  margin: 0 auto;
+  text-align: center;
+  line-height: 1.4;
+  padding: 0 140px;
+}
+/* line 40, components/_inline-messages.scss */
+.notice em {
+  background: url(../images/tick.svg) center center no-repeat #a471f0;
+  display: inline-block;
+  margin-right: 1em;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  position: relative;
+  top: 8px;
+}
 
+/* line 1, components/_tooltips.scss */
 .tooltip {
   display: none;
   position: absolute;
@@ -1118,74 +1510,97 @@ pre {
   border-radius: 3px;
   -webkit-transition: opacity 0.4s linear;
   -moz-transition: opacity 0.4s linear;
-  transition: opacity 0.4s linear; }
-  .tooltip.test-tooltip {
-    margin-left: -45px; }
-  .tooltip.active {
-    display: block;
-    -webkit-animation: floating 2s cubic-bezier(0.645, 0.045, 0.355, 1);
-    -moz-animation: floating 2s cubic-bezier(0.645, 0.045, 0.355, 1);
-    animation: floating 2s cubic-bezier(0.645, 0.045, 0.355, 1);
-    -webkit-animation-iteration-count: infinite;
-    -moz-animation-iteration-count: infinite;
-    animation-iteration-count: infinite; }
-  .tooltip:hover {
-    -webkit-animation-play-state: paused;
-    -moz-animation-play-state: paused;
-    animation-play-state: paused; }
-    .tooltip:hover:after {
-      -webkit-animation-play-state: paused;
-      -moz-animation-play-state: paused;
-      animation-play-state: paused; }
-  .open .tooltip {
-    pointer-events: none;
-    opacity: 0; }
-  .tooltip:after, .tooltip:before {
-    position: absolute;
-    left: 50%;
-    top: 100%;
-    content: '';
-    display: block;
-    width: 0px;
-    margin-left: -8px;
-    height: 0px;
-    font-size: 0px;
-    line-height: 0px;
-    border-top: solid 10px #fff;
-    border-right: solid 8px transparent;
-    border-left: solid 8px transparent;
-    z-index: 2; }
-  .tooltip:after {
-    border-top-color: #CAC6CE;
-    margin-top: 1px;
-    z-index: 1;
-    -webkit-animation: fade 2s cubic-bezier(0.645, 0.045, 0.355, 1);
-    -moz-animation: fade 2s cubic-bezier(0.645, 0.045, 0.355, 1);
-    animation: fade 2s cubic-bezier(0.645, 0.045, 0.355, 1);
-    -webkit-animation-iteration-count: infinite;
-    -moz-animation-iteration-count: infinite;
-    animation-iteration-count: infinite; }
+  transition: opacity 0.4s linear;
+}
+/* line 17, components/_tooltips.scss */
+.tooltip.test-tooltip {
+  margin-left: -45px;
+}
+/* line 21, components/_tooltips.scss */
+.tooltip.active {
+  display: block;
+  -webkit-animation: floating 2s cubic-bezier(0.645, 0.045, 0.355, 1);
+  -moz-animation: floating 2s cubic-bezier(0.645, 0.045, 0.355, 1);
+  animation: floating 2s cubic-bezier(0.645, 0.045, 0.355, 1);
+  -webkit-animation-iteration-count: infinite;
+  -moz-animation-iteration-count: infinite;
+  animation-iteration-count: infinite;
+}
+/* line 27, components/_tooltips.scss */
+.tooltip:hover {
+  -webkit-animation-play-state: paused;
+  -moz-animation-play-state: paused;
+  animation-play-state: paused;
+}
+/* line 30, components/_tooltips.scss */
+.tooltip:hover:after {
+  -webkit-animation-play-state: paused;
+  -moz-animation-play-state: paused;
+  animation-play-state: paused;
+}
+/* line 35, components/_tooltips.scss */
+.open .tooltip {
+  pointer-events: none;
+  opacity: 0;
+}
+/* line 40, components/_tooltips.scss */
+.tooltip:after, .tooltip:before {
+  position: absolute;
+  left: 50%;
+  top: 100%;
+  content: '';
+  display: block;
+  width: 0px;
+  margin-left: -8px;
+  height: 0px;
+  font-size: 0px;
+  line-height: 0px;
+  border-top: solid 10px #fff;
+  border-right: solid 8px transparent;
+  border-left: solid 8px transparent;
+  z-index: 2;
+}
+/* line 58, components/_tooltips.scss */
+.tooltip:after {
+  border-top-color: #CAC6CE;
+  margin-top: 1px;
+  z-index: 1;
+  -webkit-animation: fade 2s cubic-bezier(0.645, 0.045, 0.355, 1);
+  -moz-animation: fade 2s cubic-bezier(0.645, 0.045, 0.355, 1);
+  animation: fade 2s cubic-bezier(0.645, 0.045, 0.355, 1);
+  -webkit-animation-iteration-count: infinite;
+  -moz-animation-iteration-count: infinite;
+  animation-iteration-count: infinite;
+}
 
 @-webkit-keyframes floating {
   0% {
     -webkit-transform: translateY(0px);
-    border-color: #7e7487; }
+    border-color: #7e7487;
+  }
   50% {
     -webkit-transform: translateY(-10px);
-    border-color: #CAC6CE; }
+    border-color: #CAC6CE;
+  }
   100% {
     -webkit-transform: translateY(0px);
-    border-color: #7e7487; } }
+    border-color: #7e7487;
+  }
+}
 @-moz-keyframes floating {
   0% {
     -moz-transform: translateY(0px);
-    border-color: #7e7487; }
+    border-color: #7e7487;
+  }
   50% {
     -moz-transform: translateY(-10px);
-    border-color: #CAC6CE; }
+    border-color: #CAC6CE;
+  }
   100% {
     -moz-transform: translateY(0px);
-    border-color: #7e7487; } }
+    border-color: #7e7487;
+  }
+}
 @keyframes floating {
   0% {
     -webkit-transform: translateY(0px);
@@ -1193,89 +1608,134 @@ pre {
     -ms-transform: translateY(0px);
     -o-transform: translateY(0px);
     transform: translateY(0px);
-    border-color: #7e7487; }
+    border-color: #7e7487;
+  }
   50% {
     -webkit-transform: translateY(-10px);
     -moz-transform: translateY(-10px);
     -ms-transform: translateY(-10px);
     -o-transform: translateY(-10px);
     transform: translateY(-10px);
-    border-color: #CAC6CE; }
+    border-color: #CAC6CE;
+  }
   100% {
     -webkit-transform: translateY(0px);
     -moz-transform: translateY(0px);
     -ms-transform: translateY(0px);
     -o-transform: translateY(0px);
     transform: translateY(0px);
-    border-color: #7e7487; } }
+    border-color: #7e7487;
+  }
+}
 @-webkit-keyframes fade {
   0% {
-    border-top-color: #7e7487; }
+    border-top-color: #7e7487;
+  }
   50% {
-    border-top-color: #CAC6CE; }
+    border-top-color: #CAC6CE;
+  }
   100% {
-    border-top-color: #7e7487; } }
+    border-top-color: #7e7487;
+  }
+}
 @-moz-keyframes fade {
   0% {
-    border-top-color: #7e7487; }
+    border-top-color: #7e7487;
+  }
   50% {
-    border-top-color: #CAC6CE; }
+    border-top-color: #CAC6CE;
+  }
   100% {
-    border-top-color: #7e7487; } }
+    border-top-color: #7e7487;
+  }
+}
 @keyframes fade {
   0% {
-    border-top-color: #7e7487; }
+    border-top-color: #7e7487;
+  }
   50% {
-    border-top-color: #CAC6CE; }
+    border-top-color: #CAC6CE;
+  }
   100% {
-    border-top-color: #7e7487; } }
+    border-top-color: #7e7487;
+  }
+}
 /* Views */
 /* Shared */
+/* line 2, views/_all.scss */
 body {
-  background-color: #F7F6F8; }
-  body.signup {
-    background-color: #fff; }
+  background-color: #F7F6F8;
+}
+/* line 5, views/_all.scss */
+body.signup {
+  background-color: #fff;
+}
 
+/* line 10, views/_all.scss */
 header {
   background-color: #3E3C41;
   line-height: 80px;
-  height: 80px; }
-  header p {
-    margin: 0;
-    color: #CAC6CE;
-    font-size: 13px; }
+  height: 80px;
+}
+/* line 15, views/_all.scss */
+header p {
+  margin: 0;
+  color: #CAC6CE;
+  font-size: 13px;
+}
 
+/* line 22, views/_all.scss */
 aside {
-  padding: 2.6em 0 3em; }
-  aside p {
-    margin-top: .5em; }
+  padding: 2.6em 0 3em;
+}
+/* line 25, views/_all.scss */
+aside p {
+  margin-top: .5em;
+}
 
+/* line 30, views/_all.scss */
 .introduction {
-  margin-bottom: 60px; }
+  margin-bottom: 60px;
+}
 
 /* Sign Up */
+/* line 35, views/_all.scss */
 .signup {
-  border-top: solid 3px #3E3C41; }
-  .signup .middle p, .signup .bar .pane .success-middle p, .bar .pane .signup .success-middle p, .signup .notice p p, .notice .signup p p {
-    margin-top: 2.95em; }
+  border-top: solid 3px #3E3C41;
+}
+/* line 38, views/_all.scss */
+.signup .middle p, .signup .bar .pane .success-middle p, .bar .pane .signup .success-middle p, .signup .bar .pane .error-middle p, .bar .pane .signup .error-middle p, .signup .notice p p, .notice .signup p p {
+  margin-top: 2.95em;
+}
 
 /* Connect */
+/* line 45, views/_all.scss */
 .paypal-braintree .paypal-logo {
   margin-bottom: 1em;
   float: left;
-  height: 30px; }
+  height: 30px;
+}
+/* line 51, views/_all.scss */
 .paypal-braintree p {
   display: block;
   clear: both;
-  max-width: 27em; }
-  .paypal-braintree p a {
-    font-family: "Open Sans Semibold", "Helvetica Neue", Helvetica, Arial, Sans-serif;
-    text-decoration: none; }
-    .paypal-braintree p a:hover {
-      text-decoration: underline; }
+  max-width: 27em;
+}
+/* line 56, views/_all.scss */
+.paypal-braintree p a {
+  font-family: "Open Sans Semibold", "Helvetica Neue", Helvetica, Arial, Sans-serif;
+  text-decoration: none;
+}
+/* line 60, views/_all.scss */
+.paypal-braintree p a:hover {
+  text-decoration: underline;
+}
+/* line 66, views/_all.scss */
 .paypal-braintree ul {
   margin: -2px 0 10px;
-  float: right; }
+  float: right;
+}
+/* line 71, views/_all.scss */
 .paypal-braintree li {
   background: url(/assets/images/icons/visa.png) center center no-repeat #fff;
   background-size: 44px auto;
@@ -1286,29 +1746,44 @@ aside {
   height: 30px;
   border: solid 1px #D1CED4;
   text-indent: -999em;
-  border-radius: 1px; }
-  .paypal-braintree li.mastercard {
-    background-image: url(/assets/images/icons/mastercard.png); }
-  .paypal-braintree li.amex {
-    background-image: url(/assets/images/icons/amex.png); }
-  .paypal-braintree li.discover {
-    background-image: url(/assets/images/icons/discover.png); }
-  .paypal-braintree li.paypal {
-    background-image: url(/assets/images/icons/paypal.png); }
+  border-radius: 1px;
+}
+/* line 83, views/_all.scss */
+.paypal-braintree li.mastercard {
+  background-image: url(/assets/images/icons/mastercard.png);
+}
+/* line 84, views/_all.scss */
+.paypal-braintree li.amex {
+  background-image: url(/assets/images/icons/amex.png);
+}
+/* line 85, views/_all.scss */
+.paypal-braintree li.discover {
+  background-image: url(/assets/images/icons/discover.png);
+}
+/* line 86, views/_all.scss */
+.paypal-braintree li.paypal {
+  background-image: url(/assets/images/icons/paypal.png);
+}
 
+/* line 90, views/_all.scss */
 .braintree-button {
   display: inline-block;
-  margin-top: 1.5em; }
-  .braintree-button img {
-    float: left; }
+  margin-top: 1.5em;
+}
+/* line 94, views/_all.scss */
+.braintree-button img {
+  float: left;
+}
 
+/* line 99, views/_all.scss */
 table {
-  border: 1px solid #CAC6CE; }
+  border: 1px solid #CAC6CE;
+}
 
+/* line 103, views/_all.scss */
 td, th {
   padding: 10px;
-  border-bottom: 1px solid #CAC6CE; }
+  border-bottom: 1px solid #CAC6CE;
+}
 
 /* Connected */
-
-/*# sourceMappingURL=global.css.map */

--- a/public/assets/javascript/global.js
+++ b/public/assets/javascript/global.js
@@ -5,6 +5,7 @@ function App(){
   this.$payForm = $('#paymentForm');
   this.$payButton = $('.button.primary');
   this.$paySuccess = $('.success');
+  this.$payError = $('.error');
   this.$noticeEnabled = $('.notice-enabled');
   this.$noticePayment = $('.notice-payment');
 
@@ -84,6 +85,21 @@ App.prototype.showPaymentSuccess = function(){
       self.$noticePayment.addClass(self.showClass);
     }, 600);
   }, 2000);
+};
+
+App.prototype.showError = function(message){
+  var self = this;
+  var pane = $('.pane');
+
+  this.$payError.find('.message').text(message || 'Something went wrong');
+  this.$payError.addClass(this.showClass);
+
+  window.setTimeout(function(){
+    app.closePane(pane, function() {
+      self.$payError.removeClass(self.showClass);
+    });
+    app.clearPaymentLoading();
+  }, 5000);
 };
 
 App.prototype.labelFocus = function(parent){
@@ -167,7 +183,7 @@ App.prototype.openPane = function(pane){
   }, 200);
 };
 
-App.prototype.closePane = function(pane){
+App.prototype.closePane = function(pane, callback){
   var self = this;
   var toggle = pane.find('.toggle');
 
@@ -181,6 +197,9 @@ App.prototype.closePane = function(pane){
 
   window.setTimeout(function(){
     toggle.css({"width": toggle.data("original-width")});
+    if (callback) {
+      callback();
+    }
   }, 400);
 };
 

--- a/views/merchant.erb
+++ b/views/merchant.erb
@@ -124,7 +124,12 @@
                   <p>Password: 11111111</p>
                 </li>
                 <li>
-                  <h6>Credit Card</h6>
+                  <h6>
+                    Credit Card
+                    <% if @three_d_secure_enabled %>
+                      (<a href="https://developers.braintreepayments.com/guides/3d-secure/testing-go-live/" target="_blank" rel="noopener">3DS testing</a>)
+                    <% end %>
+                  </h6>
                   <p>Number: 4111 1111 1111 1111</p>
                   <p>Expiration: 11/22</p>
                 </li>

--- a/views/merchant.erb
+++ b/views/merchant.erb
@@ -50,6 +50,13 @@
           This user has connected a Braintree account to PseudoShop! Click "Test Payment" below to run a transaction on their behalf.
         </p>
 
+        <% if @three_d_secure_enabled %>
+          <p>
+            3D Secure is <strong>enabled</strong> for this merchant.
+            <label><input type="checkbox" id="require3DS" checked="checked">&nbsp;Require 3DS</label>
+          </p>
+        <% end %>
+
         <h3>Today's Transactions:</h3>
         <% if @transactions.empty? %>
           <p>No transactions to show! Trying running one below to see how to view a merchant's transactions.</p>
@@ -128,6 +135,7 @@
                   <div class="group" id='paypalContainer'></div>
                   <input type='hidden' name='transaction[amount]' value='15.00' />
                   <input type='hidden' id='paymentMethodNonce' name='transaction[paymentMethodNonce]' value='true' />
+                  <input type='hidden' id='optionsRequire3DS' name='require3DS' value='true' />
 
                   <label for="card-number">
                     <span class="label">Card Number</span>
@@ -153,6 +161,15 @@
                 </div>
               </div>
 
+              <div class="error">
+                <div class="error-content">
+                  <div class="error-middle">
+                    <h3>Oh no!</h3>
+                    <p class="message"></p>
+                  </div>
+                </div>
+              </div>
+
             </section>
           </li>
         <% end %>
@@ -167,11 +184,12 @@
 
 <% if @client_token %>
   <script>
-    var client = braintree.setup('<%= @client_token %>', 'custom', {
+    var isThreeDSEnabledMerchant = <%= @three_d_secure_enabled %>;
+    braintree.setup('<%= @client_token %>', 'custom', {
       id: "paymentForm",
       hostedFields: {
         onFieldEvent: function (event) {
-          if(event.type === "fieldStateChange" && !event.isValid){
+          if(event.type === "fieldStateChange" && !event.isValid) {
             console.log("No go! Clear loading state");
             app.clearPaymentLoading();
           }
@@ -197,24 +215,11 @@
       onPaymentMethodReceived: function (event) {
         var form = $('#paymentForm');
         var url = form.attr('action');
-        document.getElementById('paymentMethodNonce').value = event.nonce;
-        $.ajax({
-          type: "POST",
-          url: url,
-          data: form.serialize(),
-          success: function(response){
-            console.log(response);
-            if (response.success) {
-              app.showPaymentSuccess();
-            } else {
-              app.clearPaymentLoading();
-              alert('transaction failed: ' + response.errors);
-            }
-          },
-          error: function(error){
-            console.log(error);
-          }
-        });
+        if (isThreeDSEnabledMerchant) {
+          threeDSFlow(form, url, event.nonce)
+        } else {
+          submitTransaction(form, url, event.nonce);
+        }
       },
       paypal: {
         container: "paypalContainer",
@@ -224,5 +229,75 @@
         enableShippingAddress: true,
       }
     });
+
+    function submitTransaction(form, url, nonce) {
+      document.getElementById('paymentMethodNonce').value = nonce;
+      document.getElementById('optionsRequire3DS').value = $('#require3DS').is(':checked');
+      $.ajax({
+        type: "POST",
+        url: url,
+        data: form.serialize(),
+        success: function(response){
+          if (response.success) {
+            app.showPaymentSuccess();
+          } else {
+            console.log(response);
+            app.clearPaymentLoading();
+            alert('transaction failed: ' + response.errors);
+          }
+        },
+        error: function(error){
+          console.log(error);
+        }
+      });
+    }
+
+    function threeDSFlow(form, url, nonce) {
+      var threeDSClient = new braintree.api.Client({
+        authorization: '<%= @client_token %>'
+      });
+
+      threeDSClient.verify3DS({
+        amount: 15.00,
+        creditCard: nonce,
+        onUserClose: function() {
+          app.clearPaymentLoading();
+        }
+      }, function (error, response) {
+        if (error) {
+          alert('verify3DS failed: ' + error.message);
+          return;
+        }
+
+        var liabilityShifted = response.verificationDetails.liabilityShifted;
+        var liabilityShiftPossible =  response.verificationDetails.liabilityShiftPossible;
+        var require3DS = $('#require3DS').is(':checked');
+
+        if (liabilityShifted) {
+          submitTransaction(form, url, response.nonce);
+          return;
+        }
+
+        if (liabilityShiftPossible) {
+          if (require3DS) {
+            app.showError('3DS is required, but 3DS verification failed');
+            app.clearPaymentLoading();
+          } else {
+            alert('3DS verification failed, but continuing because 3DS is not required');
+            submitTransaction(form, url, response.nonce);
+          }
+          return;
+        }
+
+        if (require3DS) {
+          app.showError('3DS is required, but the provided card is not eligible for 3DS');
+          app.clearPaymentLoading();
+        } else {
+          alert('The provided card is not eligible for 3DS, but continuing because 3DS is not required');
+          submitTransaction(form, url, response.nonce);
+        }
+      });
+    }
+
   </script>
 <% end %>

--- a/views/merchant.erb
+++ b/views/merchant.erb
@@ -72,7 +72,7 @@
             <% @transactions.each do |transaction| %>
               <tr>
                 <td>
-                  <a href="https://sandbox.braintreegateway.com/merchants/<%= @merchant.braintree_id %>/transactions/<%= transaction.id %>"><%= transaction.id %></a>
+                  <a href="https://<%= settings.gateway_host %>/merchants/<%= @merchant.braintree_id %>/transactions/<%= transaction.id %>"><%= transaction.id %></a>
                 </td>
                 <td><%= "$%05.2f" % transaction.amount %></td>
                 <td><%= transaction.status.titleize %></td>
@@ -89,7 +89,7 @@
           new BraintreeOAuthConnect({
             connectUrl: '<%= @connect_url %>',
             container: 'bt-oauth-connect-container',
-            environment: 'sandbox',
+            environment: '<%= settings.gateway_environment %>',
             onError: function (errorObject) {
               console.warn(errorObject.message);
             }


### PR DESCRIPTION
This PR adds 3DS support to PseudoShop. What this means is that PseudoShop will behave slightly differently for 3DS-enabled partners:
1. A "3D Secure is enabled for this merchant" message will display if the partner is enabled for 3DS.
2. Next to that message, a checkbox will be displayed, which toggles whether or not 3DS is required for transactions. Anything other than successful 3DS verification is an error if it is required; when not required, an alert will display indicating a problem verifying the card, but the transaction will proceed as normal.
3. Specific credit card numbers must be used to emulate ones that are enrolled in 3DS; others will be treated as not eligible for 3DS. These numbers can be found [here](https://developers.braintreepayments.com/guides/3d-secure/testing-go-live/ruby).

These changes will not affect merchants that are not enabled for 3DS in any way.
