### PR TITLE
Bump dependency versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem "sinatra", "1.4.7"
 gem "sinatra-activerecord", "2.0.13"
 gem "rake", "10.4.2"
 
-gem "braintree", "2.54.0"
+gem "braintree", "2.87.0"
 
 gem "unicorn", "4.9.0"
 gem "remote_syslog_logger", "1.0.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     arel (8.0.0)
-    braintree (2.54.0)
+    braintree (2.87.0)
       builder (>= 2.0.0)
     builder (3.2.3)
     concurrent-ruby (1.0.5)
@@ -55,7 +55,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  braintree (= 2.54.0)
+  braintree (= 2.87.0)
   dotenv (= 2.1.1)
   pg (= 0.18.2)
   rake (= 10.4.2)
@@ -68,4 +68,4 @@ DEPENDENCIES
   unicorn (= 4.9.0)
 
 BUNDLED WITH
-   1.14.6
+   1.16.1

--- a/db/migrate/20151002181155_create_merchants.rb
+++ b/db/migrate/20151002181155_create_merchants.rb
@@ -1,4 +1,4 @@
-class CreateMerchants < ActiveRecord::Migration
+class CreateMerchants < ActiveRecord::Migration[5.0]
   def change
     create_table :merchants do |t|
       t.string :email

--- a/db/migrate/20160809160330_add_country_code.rb
+++ b/db/migrate/20160809160330_add_country_code.rb
@@ -1,4 +1,4 @@
-class AddCountryCode < ActiveRecord::Migration
+class AddCountryCode < ActiveRecord::Migration[5.0]
   def change
     add_column :merchants, :country_code, :string, :default => 'USA'
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -19,8 +19,8 @@ ActiveRecord::Schema.define(version: 20160809160330) do
     t.string "braintree_id"
     t.string "public_id"
     t.string "state"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "country_code", default: "USA"
   end
 

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -5,9 +5,9 @@
     <title>PseudoShop</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="/assets/css/global.css">
-    <script src="https://js.braintreegateway.com/web/3.6.0/js/client.min.js"></script>
-    <script src="https://js.braintreegateway.com/web/3.6.0/js/hosted-fields.min.js"></script>
-    <script src="https://js.braintreegateway.com/web/3.6.0/js/paypal.min.js"></script>
+    <script src="https://js.braintreegateway.com/web/3.32.1/js/client.min.js"></script>
+    <script src="https://js.braintreegateway.com/web/3.32.1/js/hosted-fields.min.js"></script>
+    <script src="https://js.braintreegateway.com/web/3.32.1/js/paypal.min.js"></script>
     <script src="https://assets.braintreegateway.com/v1/braintree-oauth-connect.js"></script>
     <script type="text/javascript" src="/assets/javascript/vendor/jquery-2.1.4.min.js"></script>
   </head>


### PR DESCRIPTION
Bump Braintree Ruby gem to 2.87.0
Bump Braintree Web to 3.32.1

Pin migrations to rails 5 to avoid change in 5.1 preventing you from inheriting from `ActiveRecord::Migration` directly.